### PR TITLE
Remove obsolete attribute: version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
I received this warning when running `docker-compose up`

```bash
WARN[0000] /home/libuk/code/last-lifts/docker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```