### PR TITLE
Use COPY directive to copy SQL scripts to docker entrypoint

### DIFF
--- a/docker/DockerfileDb
+++ b/docker/DockerfileDb
@@ -1,4 +1,4 @@
 FROM mysql:8.0.32
 
-ADD ../src/app/database/01-create-database.sql /docker-entrypoint-initdb.d
-ADD ../src/app/database/02-create-table-lifters.sql /docker-entrypoint-initdb.d
+COPY ../src/app/database/01-create-database.sql /docker-entrypoint-initdb.d
+COPY ../src/app/database/02-create-table-lifters.sql /docker-entrypoint-initdb.d


### PR DESCRIPTION
For some reason, ADD didn't work. I don't understand why as both should copy files from the current build context.